### PR TITLE
fix: auto-deployment for FE and BE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          VITE_API_URL: ${{ secrets.VITE_API_URL || 'http://localhost:8000' }}
+          # Set in GitHub → Settings → Secrets to your Render backend URL.
+          # No localhost fallback — a missing secret should be a visible failure.
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_BASE_PATH: /Bookmate/
 
   backend:
     name: Test backend
@@ -54,8 +57,21 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Run tests
-        run: pytest
+        run: pytest -v
         env:
           DATABASE_URL: sqlite+aiosqlite:///./test_bookmate.db
           JWT_SECRET_KEY: test-secret-key
           BACKEND_CORS_ORIGINS: http://localhost:5173
+
+  deploy-backend:
+    name: Deploy backend to Render
+    needs: backend
+    # Only deploy on direct pushes to main (not PRs)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy hook
+        # Set RENDER_DEPLOY_HOOK_URL in GitHub → Settings → Secrets.
+        # Get the URL from: Render dashboard → your service → Settings → Deploy Hook.
+        run: |
+          curl -fsSL -X POST "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,9 @@ jobs:
         run: npm run build
         working-directory: src/Bookmate.UI
         env:
-          VITE_API_URL: ${{ secrets.VITE_API_URL || 'http://localhost:8000' }}
+          # Must be set in GitHub → Settings → Secrets (your Render backend URL).
+          # Intentionally no localhost fallback — a blank URL is caught at build time.
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
           VITE_BASE_PATH: /${{ github.event.repository.name }}/
 
       - name: Add SPA fallback for GitHub Pages

--- a/src/Bookmate.API/pytest.ini
+++ b/src/Bookmate.API/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/src/Bookmate.API/tests/test_books.py
+++ b/src/Bookmate.API/tests/test_books.py
@@ -1,11 +1,14 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from app.main import app
+
 
 @pytest.mark.asyncio
 async def test_create_and_list():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        res = await ac.post("/api/books", json={"title":"My Book","author":"Me"})
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        res = await ac.post("/api/books", json={"title": "My Book", "author": "Me"})
         assert res.status_code == 201
         data = res.json()
         assert data["title"] == "My Book"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/Bookmate/src/Bookmate.UI/',
+  // VITE_BASE_PATH is injected by CI/deploy workflows.
+  // Locally it falls back to '/' so dev server works normally.
+  base: process.env.VITE_BASE_PATH || '/',
   plugins: [react()],
 })


### PR DESCRIPTION
- vite.config.ts: fix hardcoded base '/Bookmate/src/Bookmate.UI/' → reads VITE_BASE_PATH env var (injected by workflows), falls back to '/' locally
- ci.yml: remove 'localhost:8000' fallback from VITE_API_URL (baked wrong URL into production bundle when secret was unset); add VITE_BASE_PATH to FE build step; add deploy-backend job that triggers Render deploy hook after tests pass (push to main only, not PRs)
- deploy.yml: same VITE_API_URL localhost fallback removed
- tests/test_books.py: fix deprecated AsyncClient(app=...) → ASGITransport (httpx >= 0.20 requires explicit transport)
- pytest.ini: add asyncio_mode = auto so pytest-asyncio works without per-test decorator config

Required GitHub secrets to set (Settings → Secrets → Actions):
  VITE_API_URL          — your Render backend URL
  RENDER_DEPLOY_HOOK_URL — from Render dashboard → service → Settings → Deploy Hook